### PR TITLE
Add Dockerified version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.6.0-stretch
+
+COPY /filebeat_cleaner.rb /filebeat_cleaner.rb
+
+ENTRYPOINT [ "ruby", "filebeat_cleaner.rb" ]


### PR DESCRIPTION
While FileBeat doesn't have native deletion capabilities, it would be really handy to have a dockerified version of this.

For Kubernetes folks, we'd put this alongside a filebeat container and another container with a glob of storage holding all 3 together.